### PR TITLE
Fix focuslast command

### DIFF
--- a/dvtm.c
+++ b/dvtm.c
@@ -1235,7 +1235,7 @@ focusprevnm(const char *args[]) {
 
 static void
 focuslast(const char *args[]) {
-	if (lastsel)
+	if (lastsel && isvisible(lastsel))
 		focus(lastsel);
 }
 


### PR DESCRIPTION
The last window should be focused iff there was a last window AND that
window is still visible.