### PR TITLE
Revert "Add config.def.h as a dependency for config.h"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEBUG_CFLAGS = ${CFLAGS} -UNDEBUG -O0 -g -ggdb -Wall -Wextra -Wno-unused-paramet
 
 all: dvtm dvtm-editor
 
-config.h: config.def.h
+config.h:
 	cp config.def.h config.h
 
 dvtm: config.h config.mk *.c *.h


### PR DESCRIPTION
Reverts mthowe/dvtm#1

Reverting this purely for the sake of being consistent with other suckless.org projects.